### PR TITLE
Bumps node deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "posttest": "npm run lint"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-preset-es2015": "^6.3.13",
-    "eslint": "^2.3.0",
+    "babel-cli": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "eslint": "^2.7.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-config-standard-react": "2.3.0",
     "eslint-plugin-standard": "^1.3.2",
     "faucet": "0.0.1",
-    "tape": "^4.2.2"
+    "tape": "^4.5.1"
   }
 }


### PR DESCRIPTION
This PR adds minor bumps the following node_modules:
- babel-cli
- babel-preset-es2015
- eslint
- tape
